### PR TITLE
Show corresponding object for transactions

### DIFF
--- a/src/#mbtools#cl_command.clas.abap
+++ b/src/#mbtools#cl_command.clas.abap
@@ -74,6 +74,12 @@ CLASS /mbtools/cl_command DEFINITION
       RETURNING
         VALUE(rr_range) TYPE /mbtools/if_definitions=>ty_name_range.
 
+    METHODS name_adjust
+      IMPORTING
+        !iv_obj_name       TYPE csequence
+      RETURNING
+        VALUE(rv_obj_name) TYPE string.
+
     METHODS object_split
       IMPORTING
         !iv_object      TYPE string
@@ -212,6 +218,22 @@ CLASS /mbtools/cl_command IMPLEMENTATION.
   ENDMETHOD.
 
 
+  METHOD name_adjust.
+
+    DATA lv_len TYPE i.
+
+    lv_len = strlen( iv_obj_name ) - 1.
+
+    " Remove trailing #
+    IF lv_len > 0 AND iv_obj_name+lv_len(1) = '#'.
+      rv_obj_name = iv_obj_name(lv_len).
+    ELSE.
+      rv_obj_name = iv_obj_name.
+    ENDIF.
+
+  ENDMETHOD.
+
+
   METHOD name_split.
 
     DATA:
@@ -225,6 +247,8 @@ CLASS /mbtools/cl_command IMPLEMENTATION.
     IF iv_obj_name CS c_split-values.
       SPLIT iv_obj_name AT c_split-values INTO TABLE lt_obj_name.
       LOOP AT lt_obj_name INTO lv_obj_name.
+        lv_obj_name = name_adjust( lv_obj_name ).
+
         APPEND INITIAL LINE TO rr_range ASSIGNING <lr_range>.
 
         range_derive(
@@ -240,11 +264,13 @@ CLASS /mbtools/cl_command IMPLEMENTATION.
         <lr_range>-high = /mbtools/cl_sap=>object_name_check( <lr_range>-high ).
       ENDLOOP.
     ELSE.
+      lv_obj_name = name_adjust( iv_obj_name ).
+
       APPEND INITIAL LINE TO rr_range ASSIGNING <lr_range>.
 
       range_derive(
         EXPORTING
-          iv_input  = iv_obj_name
+          iv_input  = lv_obj_name
         IMPORTING
           ev_sign   = <lr_range>-sign
           ev_option = <lr_range>-option

--- a/src/#mbtools#cl_command__show.clas.abap
+++ b/src/#mbtools#cl_command__show.clas.abap
@@ -39,6 +39,24 @@ CLASS /mbtools/cl_command__show DEFINITION
       RETURNING
         VALUE(rv_exit) TYPE abap_bool.
 
+    CLASS-METHODS show_code
+      IMPORTING
+        !is_tadir_key  TYPE /mbtools/if_definitions=>ty_tadir_key
+      RETURNING
+        VALUE(rv_exit) TYPE abap_bool.
+
+    CLASS-METHODS is_code_command
+      IMPORTING
+        !iv_object_name  TYPE csequence
+      RETURNING
+        VALUE(rv_result) TYPE abap_bool.
+
+    CLASS-METHODS get_object_from_tcode
+      IMPORTING
+        !iv_object_name     TYPE csequence
+      RETURNING
+        VALUE(rs_tadir_key) TYPE /mbtools/if_definitions=>ty_tadir_key.
+
 ENDCLASS.
 
 
@@ -90,7 +108,11 @@ CLASS /mbtools/cl_command__show IMPLEMENTATION.
         ENDTRY.
 
         " Show object definition
-        cv_exit = show_tool( ls_tadir_key ).
+        IF is_code_command( lv_object_name ) = abap_true.
+          cv_exit = show_code( ls_tadir_key ).
+        ELSE.
+          cv_exit = show_tool( ls_tadir_key ).
+        ENDIF.
 
         IF lv_tadir_count = 1.
           EXIT.
@@ -117,6 +139,153 @@ CLASS /mbtools/cl_command__show IMPLEMENTATION.
   METHOD class_constructor.
 
     CREATE OBJECT go_command.
+
+  ENDMETHOD.
+
+
+  METHOD get_object_from_tcode.
+
+    DATA:
+      lv_tcode  TYPE tstc-tcode,
+      lv_param  TYPE tstcp-param,
+      ls_report TYPE srepovari,
+      lv_class  TYPE seoclsname,
+      lv_method TYPE seocmpname,
+      lv_object TYPE c LENGTH 120.
+
+    lv_tcode = iv_object_name.
+
+    rs_tadir_key-pgmid = 'R3TR'.
+
+    " Report transaction
+    CALL FUNCTION 'SRT_GET_REPORT_OF_TCODE'
+      EXPORTING
+        tcode                 = lv_tcode
+      IMPORTING
+        report_structure      = ls_report
+      EXCEPTIONS
+        no_report_transaction = 1
+        OTHERS                = 2.
+    IF sy-subrc = 0 AND ls_report-report IS NOT INITIAL.
+      rs_tadir_key-object   = 'PROG'.
+      rs_tadir_key-obj_name = ls_report-report.
+      RETURN.
+    ENDIF.
+
+    " Parameter Transaction
+    SELECT SINGLE param INTO lv_param FROM tstcp WHERE tcode = lv_tcode.
+    IF sy-subrc <> 0.
+      RETURN.
+    ENDIF.
+
+    FIND REGEX 'RS38M-PROGRAMM=(.+);' IN lv_param SUBMATCHES lv_object.
+    IF sy-subrc <> 0.
+      FIND REGEX '\\PROGRAM=(.+)\\CLASS' IN lv_param SUBMATCHES lv_object.
+    ENDIF.
+
+    IF lv_object IS NOT INITIAL.
+      rs_tadir_key-object   = 'PROG'.
+      rs_tadir_key-obj_name = lv_object.
+      RETURN.
+    ENDIF.
+
+    FIND REGEX 'CLASS=(.+);' IN lv_param SUBMATCHES lv_class.
+    IF sy-subrc = 0.
+      FIND REGEX 'METHOD=(.+);' IN lv_param SUBMATCHES lv_method.
+    ELSE.
+      FIND REGEX '\\CLASS=(.+)\\METHOD=(.+)' IN lv_param SUBMATCHES lv_class lv_method.
+    ENDIF.
+
+    IF lv_class IS NOT INITIAL.
+      SYSTEM-CALL QUERY CLASS lv_class.              "#EC CI_SYSTEMCALL
+      IF sy-subrc = 0.
+        rs_tadir_key-object   = 'CLAS'.
+        rs_tadir_key-obj_name = lv_class.
+        IF lv_method IS NOT INITIAL.
+          SYSTEM-CALL QUERY METHOD lv_method OF CLASS lv_class
+            INCLUDE INTO lv_object NO DBLOCK.        "#EC CI_SYSTEMCALL
+          IF sy-subrc = 0.
+            rs_tadir_key-object   = 'PROG'.
+            rs_tadir_key-obj_name = lv_object.
+            RETURN.
+          ELSE.
+            RETURN.
+          ENDIF.
+        ELSE.
+          RETURN.
+        ENDIF.
+      ENDIF.
+    ENDIF.
+
+    FIND REGEX 'TABLENAME=(.+);' IN lv_param SUBMATCHES lv_object.
+    IF sy-subrc = 0.
+      rs_tadir_key-object   = 'TABL'.
+      rs_tadir_key-obj_name = lv_object.
+      RETURN.
+    ENDIF.
+
+    FIND REGEX 'VIEWNAME=(.+);' IN lv_param SUBMATCHES lv_object.
+    IF sy-subrc = 0.
+      rs_tadir_key-object   = 'VIEW'.
+      rs_tadir_key-obj_name = lv_object.
+      RETURN.
+    ENDIF.
+
+    FIND REGEX 'VCLNAME=(.+);' IN lv_param SUBMATCHES lv_object.
+    IF sy-subrc = 0.
+      rs_tadir_key-object   = 'VIEW'.
+      rs_tadir_key-obj_name = lv_object.
+      RETURN.
+    ENDIF.
+
+    FIND REGEX 'WDYID.*APPLICATION=(.+);' IN lv_param SUBMATCHES lv_object.
+    IF sy-subrc = 0.
+      rs_tadir_key-object   = 'WDYA'.
+      rs_tadir_key-obj_name = lv_object.
+      RETURN.
+    ENDIF.
+
+    FIND REGEX 'SNUM.*TRNO-OBJECT=(.+);' IN lv_param SUBMATCHES lv_object.
+    IF sy-subrc = 0.
+      rs_tadir_key-object   = 'SNUM'.
+      rs_tadir_key-obj_name = lv_object.
+      RETURN.
+    ENDIF.
+
+  ENDMETHOD.
+
+
+  METHOD is_code_command.
+
+    DATA lv_len TYPE i.
+
+    lv_len = strlen( iv_object_name ) - 1.
+
+    rv_result = boolc( lv_len > 0 AND iv_object_name+lv_len(1) = '#' ).
+
+  ENDMETHOD.
+
+
+  METHOD show_code.
+
+    DATA ls_tadir_key LIKE is_tadir_key.
+
+    " Show ABAP code corresponding to object
+    ls_tadir_key = is_tadir_key.
+
+    IF ls_tadir_key-pgmid = 'R3TR' AND ls_tadir_key-object = 'TRAN'.
+      " transactions -> program / class / view
+      ls_tadir_key = get_object_from_tcode( ls_tadir_key-obj_name ).
+    ENDIF.
+
+    IF ls_tadir_key = is_tadir_key.
+      MESSAGE 'No corresponding ABAP code found' TYPE 'S'.
+    ELSE.
+      rv_exit = /mbtools/cl_sap=>show_object(
+        iv_pgmid    = ls_tadir_key-pgmid
+        iv_object   = ls_tadir_key-object
+        iv_obj_name = ls_tadir_key-obj_name ).
+    ENDIF.
 
   ENDMETHOD.
 

--- a/src/#mbtools#cl_command__show.clas.abap
+++ b/src/#mbtools#cl_command__show.clas.abap
@@ -180,9 +180,9 @@ CLASS /mbtools/cl_command__show IMPLEMENTATION.
 
     SPLIT lv_param AT ';' INTO TABLE lt_param.
 
-    FIND REGEX 'RS38M-PROGRAMM=(.+)' IN TABLE lt_param SUBMATCHES lv_object.
+    FIND REGEX '\\PROGRAM=(.+)\\CLASS' IN TABLE lt_param SUBMATCHES lv_object.
     IF sy-subrc <> 0.
-      FIND REGEX '\\PROGRAM=(.+)\\CLASS' IN TABLE lt_param SUBMATCHES lv_object.
+      FIND REGEX 'RS38M-PROGRAMM=(.+)' IN TABLE lt_param SUBMATCHES lv_object ##SUBRC_OK.
     ENDIF.
 
     IF lv_object IS NOT INITIAL.
@@ -191,11 +191,10 @@ CLASS /mbtools/cl_command__show IMPLEMENTATION.
       RETURN.
     ENDIF.
 
-    FIND REGEX 'CLASS=(.+)' IN TABLE lt_param SUBMATCHES ls_mtdkey-clsname.
-    IF sy-subrc = 0.
-      FIND REGEX 'METHOD=(.+)' IN TABLE lt_param SUBMATCHES ls_mtdkey-cpdname.
-    ELSE.
-      FIND REGEX '\\CLASS=(.+)\\METHOD=(.+)' IN TABLE lt_param SUBMATCHES ls_mtdkey-clsname ls_mtdkey-cpdname.
+    FIND REGEX '\\CLASS=(.+)\\METHOD=(.+)' IN TABLE lt_param SUBMATCHES ls_mtdkey-clsname ls_mtdkey-cpdname.
+    IF sy-subrc <> 0.
+      FIND REGEX 'CLASS=(.+)' IN TABLE lt_param SUBMATCHES ls_mtdkey-clsname ##SUBRC_OK.
+      FIND REGEX 'METHOD=(.+)' IN TABLE lt_param SUBMATCHES ls_mtdkey-cpdname ##SUBRC_OK.
     ENDIF.
 
     IF ls_mtdkey-clsname IS NOT INITIAL.
@@ -230,16 +229,16 @@ CLASS /mbtools/cl_command__show IMPLEMENTATION.
       RETURN.
     ENDIF.
 
-    FIND REGEX 'WDYID.*APPLICATION=(.+)' IN TABLE lt_param SUBMATCHES lv_object.
+    FIND REGEX 'APPLICATION=(.+)' IN TABLE lt_param SUBMATCHES lv_object.
     IF sy-subrc = 0.
       rs_tadir_key-object   = 'WDYA'.
       rs_tadir_key-obj_name = lv_object.
       RETURN.
     ENDIF.
 
-    FIND REGEX 'SNUM.*TRNO-OBJECT=(.+)' IN TABLE lt_param SUBMATCHES lv_object.
+    FIND REGEX 'TNRO-OBJECT=(.+)' IN TABLE lt_param SUBMATCHES lv_object.
     IF sy-subrc = 0.
-      rs_tadir_key-object   = 'SNUM'.
+      rs_tadir_key-object   = 'NROB'.
       rs_tadir_key-obj_name = lv_object.
       RETURN.
     ENDIF.

--- a/src/#mbtools#if_command_field.intf.abap
+++ b/src/#mbtools#if_command_field.intf.abap
@@ -1,5 +1,4 @@
-INTERFACE /mbtools/if_command_field
-  PUBLIC .
+INTERFACE /mbtools/if_command_field PUBLIC .
 
 ************************************************************************
 * MBT Command Field
@@ -7,18 +6,23 @@ INTERFACE /mbtools/if_command_field
 * Copyright 2021 Marc Bernard <https://marcbernardtools.com/>
 * SPDX-License-Identifier: GPL-3.0-only
 ************************************************************************
+
+  " TODO: Replace with /mbtools/cl_sap constants
+
   CONSTANTS:
     BEGIN OF c_pgmid,
       r3tr  TYPE pgmid VALUE 'R3TR',
       limu  TYPE pgmid VALUE 'LIMU',
-      basis TYPE pgmid VALUE 'ZZZZ',
-    END OF c_pgmid .
+      basis TYPE pgmid VALUE 'ZZ01',
+    END OF c_pgmid.
+
   CONSTANTS:
     BEGIN OF c_objects_db,
       tabl TYPE adir_key-object VALUE 'TABL',
       c1   TYPE c VALUE ',',
       view TYPE adir_key-object VALUE 'VIEW',
     END OF c_objects_db.
+
   CONSTANTS:
     BEGIN OF c_objects_bw,
       all  TYPE adir_key-object VALUE 'BW',
@@ -53,6 +57,7 @@ INTERFACE /mbtools/if_command_field
       c14  TYPE c VALUE ',',
       trpr TYPE adir_key-object VALUE 'TRPR',
     END OF c_objects_bw.
+
   CONSTANTS:
     BEGIN OF c_objects_abap,
       prog TYPE adir_key-object VALUE 'PROG',
@@ -71,10 +76,12 @@ INTERFACE /mbtools/if_command_field
       c7   TYPE c VALUE ',',
       type TYPE adir_key-object VALUE 'TYPE',
     END OF c_objects_abap.
+
   CONSTANTS:
     BEGIN OF c_objects_limu,
       mess TYPE adir_key-object VALUE 'MESS',
     END OF c_objects_limu.
+
   CONSTANTS:
     BEGIN OF c_objects_exec,
       prog TYPE adir_key-object VALUE 'PROG',
@@ -83,6 +90,7 @@ INTERFACE /mbtools/if_command_field
       c2   TYPE c VALUE ',',
       func TYPE adir_key-object VALUE 'FUNC',
     END OF c_objects_exec.
+
   CONSTANTS:
     BEGIN OF c_table_class,
       transp  TYPE dd02l-tabclass VALUE 'TRANSP',
@@ -97,8 +105,8 @@ INTERFACE /mbtools/if_command_field
       c5      TYPE c VALUE ',',
       append  TYPE dd02l-tabclass VALUE 'APPEND',
     END OF c_table_class.
+
   CONSTANTS:
-    " Matches /mbtools/cl_sap=>class_constructor
     BEGIN OF c_objects_basis,
       activity         TYPE adir_key-object VALUE 'ZACT',
       c1               TYPE c VALUE ',',
@@ -122,4 +130,5 @@ INTERFACE /mbtools/if_command_field
       c10              TYPE c VALUE ',',
       user             TYPE adir_key-object VALUE 'ZUSR',
     END OF c_objects_basis.
+
 ENDINTERFACE.


### PR DESCRIPTION
`?show <transaction>` displays the definition of the transaction code. Now, if you append `#` to the transaction, the corresponding base object of the transaction will be shown.

Examples:

- `?show nwbc#`: display method `cl_nwbc->se93_launch`
- `?show se91#`: display program `rsmessage`
- `?show sa01#`: display view `v_rsad2`

Closes #10